### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,1496 @@
+updates:
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/local/base
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/local/roc
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/local/confusion_matrix
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/arena/docker
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/aws/emr
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/aws/sagemaker
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/aws/sagemaker/tests/unit_tests
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/aws/athena
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/kubeflow/deployer
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/kubeflow/katib-launcher
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/kubeflow/launcher
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/kubeflow/dnntrainer
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/kubeflow/kfserving
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/ffdl/serve
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/ffdl/train
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/deploy
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/store
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/manage/subscribe
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/manage/monitor_quality
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/manage/monitor_fairness
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/watson/train
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/spark/data_preprocess_spark
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/spark/train_spark
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/spark/store_spark_model
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/ibm-components/commons/config
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/presto/query
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/gcp/container
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/sample/keras/train_classifier
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/components/webapp
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/components/webapp_launcher
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/components/inference_server_launcher
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/components/preprocess
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/components/train
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/nvidia-resnet/pipeline
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/image-captioning-gcp/src
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/helloworld-ci-sample/helloworld
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/kaggle-ci-sample/submit_result
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/kaggle-ci-sample/download_dataset
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/kaggle-ci-sample/visualize_html
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/kaggle-ci-sample/visualize_table
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/versioned-pipeline-ci-samples/kaggle-ci-sample/train_model
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: frontend
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/predict/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/model_convert/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/tf-slim/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/ovms-deployer/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: tools/bazel_builder
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: third_party/minio
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: third_party/argo
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: third_party/metadata_envoy
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: manifests/gcp_marketplace/deployer
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend/metadata_writer
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend/src/cache/deployer
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/initialization-test
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/sample-test
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/imagebuilder
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/frontend-integration-test
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/images
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/api-integration-test
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: proxy
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: frontend
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: frontend/server
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: frontend/mock-backend
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/frontend-integration-test
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/arena/docker
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/aws/sagemaker/tests/unit_tests
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: components/gcp/container/component_sdk/python
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/core/ai_platform/training
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/core/container_build
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/azure-samples/databricks-pipelines
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: samples/contrib/ibm-samples/ffdl-seldon/source/seldon-pytorch-serving-image
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/predict/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: contrib/components/openvino/ovms-deployer/containers
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: sdk/python
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend/metadata_writer
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: backend/src/apiserver/visualization
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: test/sample-test
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  directory: .
+  open-pull-requests-limit: 10
+  package-ecosystem: gomod
+  reviewers:
+  - animeshsingh
+  - ckadner
+  - Tomcli
+  - afrittoli
+  - jinchihe
+  - fenglixa
+  - drewbutlerbb4
+  - kevinyu98
+  schedule:
+    interval: daily
+version: 2

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ build:
 	licext --mode merge --source vendor/ --target third_party/license.txt --overwrite
 	# Delete vendor directory
 	rm -rf vendor
+
+build-dependabot:
+	python3 hack/create_dependabot.py

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -1,0 +1,100 @@
+import yaml
+import collections
+from pathlib import Path
+
+dependabot = {}
+dependabot['version'] = 2
+dependabot['updates'] = []
+ignored_folders = ['node_modules', 'dist', '.git', 'deprecated']
+
+def get_owners(path):
+    while not Path(path/'OWNERS').is_file():
+        path = path.parent.absolute()
+    with open(path/'OWNERS') as owner_file:
+        owners = yaml.load(owner_file)
+        return owners
+
+def get_docker_paths():
+    dockerfile_list = list(repo_path.glob('**/*ockerfile*'))
+    docker_clean_list = []
+    for dockerfile in dockerfile_list:
+        if all(x not in str(dockerfile) for x in ignored_folders):
+            if dockerfile.parents[0] not in docker_clean_list:
+                docker_clean_list.append(dockerfile.parents[0])
+    return docker_clean_list
+
+def get_npm_paths():
+    npm_list = list(repo_path.glob('**/package*.json'))
+    npm_clean_list = []
+    for npm_file in npm_list:
+        if all(x not in str(npm_file) for x in ignored_folders):
+            if npm_file.parents[0] not in npm_clean_list:
+                npm_clean_list.append(npm_file.parents[0])
+    return npm_clean_list
+
+def get_pip_paths():
+    pip_list = list(repo_path.glob('**/*requirements.txt'))
+    pip_clean_list = []
+    for pip_file in pip_list:
+        if all(x not in str(pip_file) for x in ignored_folders):
+            if pip_file.parents[0] not in pip_clean_list:
+                pip_clean_list.append(pip_file.parents[0])
+    return pip_clean_list
+
+def get_go_paths():
+    go_list = list(repo_path.glob('**/go.*'))
+    go_clean_list = []
+    for go_file in go_list:
+        if all(x not in str(go_file) for x in ignored_folders):
+            if go_file.parents[0] not in go_clean_list:
+                go_clean_list.append(go_file.parents[0])
+    return go_clean_list
+
+def append_updates(ecosystem, directory, assignees, reviewers=None):
+    config = {}
+    config['package-ecosystem'] = ecosystem
+    config['directory'] = directory
+    config['schedule']= {}
+    config['schedule']['interval'] = 'daily'
+    config['open-pull-requests-limit'] = 10
+    config['assignees'] = assignees
+    if reviewers:
+        config['reviewers'] = reviewers
+    dependabot['updates'].append(config)
+
+def main():
+    for docker_path in get_docker_paths():
+        string_path = str(docker_path)
+        assignees = get_owners(docker_path).get('approvers')
+        reviewers = get_owners(docker_path).get('reviewers')
+        append_updates('docker', string_path, assignees, reviewers)
+
+    for npm_path in get_npm_paths():
+        string_path = str(npm_path)
+        assignees = get_owners(npm_path).get('approvers')
+        reviewers = get_owners(npm_path).get('reviewers')
+        append_updates('npm', string_path, assignees, reviewers)
+
+    for pip_path in get_pip_paths():
+        string_path = str(pip_path)
+        assignees = get_owners(pip_path).get('approvers')
+        reviewers = get_owners(pip_path).get('reviewers')
+        append_updates('pip', string_path, assignees, reviewers)
+
+    for go_path in get_go_paths():
+        string_path = str(go_path)
+        assignees = get_owners(go_path).get('approvers')
+        reviewers = get_owners(go_path).get('reviewers')
+        append_updates('gomod', string_path, assignees, reviewers)
+
+    with open('.github/dependabot.yml', 'w') as outfile:
+        yaml.dump(dependabot, outfile, default_flow_style=False)
+
+    print(get_docker_paths())
+    print(get_npm_paths())
+    print(get_pip_paths())
+    print(get_go_paths())
+
+if __name__ == "__main__":
+    repo_path = Path(__file__).parents[1]
+    main()


### PR DESCRIPTION
Inspired by https://github.com/kubeflow/pipelines/issues/4682  I created a script that will create a config file for depandabot so that it knows what directories to scan. It will scan the repository for files named `*ockerfile*`, `package*.json`, `*requirements.txt` and `go.*`.  It is setup for dockerfiles, npm packages, pip dependencies and gomod at the moment. It is trivial to further customize what folders are selected if further customization is needed. It also parses the closest `OWNERS` file for a given dependency listing file, and assigns the relevant approvers and adds the relevant reviewers to the PRs it creates. 

This is a sibling PR to https://github.com/kubeflow/pipelines/pull/5015, https://github.com/kubeflow/kubeflow/pull/5542, https://github.com/kubeflow/kfserving/pull/1309, https://github.com/kubeflow/arena/pull/403, https://github.com/kubeflow/testing/pull/855, https://github.com/kubeflow/fairing/pull/550, https://github.com/kubeflow/kfp-tekton/pull/432, https://github.com/kubeflow/katib/pull/1420 and https://github.com/kubeflow/tf-operator/pull/1224.

As it stands now, there are about 107  PRs that will be created with this configuration, so it might be advisable to have some form of plan to implement it in stages or be ready to quickly go through lots of the PRs. Another option is to create a target branch for all these PRs so they can be merged into that first rather than master.

For reference, the PRs that will be created can be found here: https://github.com/DavidSpek/kfp-tekton-backend/pulls
